### PR TITLE
missing fbvFormArea id

### DIFF
--- a/templates/settings.tpl
+++ b/templates/settings.tpl
@@ -18,7 +18,7 @@
 <form class="pkp_form" id="citationStyleLanguageSettingsForm" method="post" action="{url router=$smarty.const.ROUTE_COMPONENT op="manage" category="generic" plugin=$pluginName verb="settings" save=true}">
 	{csrf}
 
-	{fbvFormArea}
+	{fbvFormArea id="citationStyleLanguagePluginSettings"}
 		{fbvFormSection}
 			{assign var="uuid" value=""|uniqid|escape}
 			<div id="primary-citation-styles-{$uuid}">


### PR DESCRIPTION
because of the PHP Warning:  assert(): Assertion failed in /home/bozana/pkp/ojs-master/lib/pkp/classes/form/FormBuilderVocabulary.inc.php on line 116