### PR TITLE
Fix wrong test for submission status

### DIFF
--- a/pages/CitationStyleLanguageHandler.inc.php
+++ b/pages/CitationStyleLanguageHandler.inc.php
@@ -108,10 +108,10 @@ class CitationStyleLanguageHandler extends Handler {
 		// Disallow access to unpublished submissions, unless the user is a
 		// journal manager or an assigned subeditor or assistant. This ensures the
 		// article preview will work for those who can see it.
-		if (!$issue || !$issue->getPublished() || $this->article->getStatus() !== STATUS_PUBLISHED) {
+		if (!$issue || !$issue->getPublished() || $this->article->getStatus() != STATUS_PUBLISHED) {
 			$userCanAccess = false;
 
-			if ($user->hasRole([ROLE_ID_SUB_EDITOR, ROLE_ID_ASSISTANT], $contextId)) {
+			if ($user && $user->hasRole([ROLE_ID_SUB_EDITOR, ROLE_ID_ASSISTANT], $contextId)) {
 				$isAssigned = false;
 				$userGroupDao = DAORegistry::getDAO('UserGroupDAO');
 				$stageAssignmentDao = DAORegistry::getDAO('StageAssignmentDAO');
@@ -128,7 +128,7 @@ class CitationStyleLanguageHandler extends Handler {
 				}
 			}
 
-			if ($user->hasRole(ROLE_ID_MANAGER, $contextId)) {
+			if ($user && $user->hasRole(ROLE_ID_MANAGER, $contextId)) {
 				$userCanAccess = true;
 			}
 

--- a/pages/CitationStyleLanguageHandler.inc.php
+++ b/pages/CitationStyleLanguageHandler.inc.php
@@ -100,8 +100,11 @@ class CitationStyleLanguageHandler extends Handler {
 		$publishedArticleDao = DAORegistry::getDAO('PublishedArticleDAO');
 		$this->article = $publishedArticleDao->getPublishedArticleByBestArticleId($journal->getId(), $userVars['submissionId'], true);
 
-		$issueDao = DAORegistry::getDAO('IssueDAO');
-		$issue = $issueDao->getById($this->article->getIssueId(), $contextId);
+		$issue = null;
+		if ($this->article) {
+			$issueDao = DAORegistry::getDAO('IssueDAO');
+			$issue = $issueDao->getById($this->article->getIssueId(), $contextId);
+		}
 
 		assert(is_a($this->article, 'PublishedArticle') && !empty($this->citationStyle));
 


### PR DESCRIPTION
The old test was always true (3 !== STATUS_PUBLISHED is always true),
so the conditional block was always entered.

Then a second bug was triggered if there was no user. Fix that, too.

Now it is possible to see or download citations for users who are
not registered or who do not have any special right.

Signed-off-by: Stefan Weil <sw@weilnetz.de>