### PR TITLE
pkp/healthSciences#12 Allow citation click events to propagate.

### DIFF
--- a/js/articleCitation.js
+++ b/js/articleCitation.js
@@ -61,7 +61,6 @@
 		}
 
 		e.preventDefault();
-		e.stopPropagation();
 
 		var url = $(this).data('json-href');
 


### PR DESCRIPTION
This allows the event where a user clicks on a citation format on the
frontned to propagate, so that third-party tools can respond. This is useful
in cases where the links appear inside other controls, like the Bootstrap 4
dropdown.