### PR TITLE
Update ABNT-NBR 6023 from 2002 to 2018 standard

### DIFF
--- a/citation-styles/associacao-brasileira-de-normas-tecnicas.csl
+++ b/citation-styles/associacao-brasileira-de-normas-tecnicas.csl
@@ -1,50 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" demote-non-dropping-particle="never" default-locale="pt-BR">
-  <!--Em caso de sobrenome composto, este nao sera desmontado para a montagem da citacao ou bibliografia como no caso de L. Van Der Pijl-->
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" initialize="false" demote-non-dropping-particle="never" default-locale="pt-BR">
   <info>
-    <title>Associação Brasileira de Normas Técnicas (Portuguese - Brazil)</title>
-    <title-short>ABNT</title-short>
-    <id>http://www.zotero.org/styles/associacao-brasileira-de-normas-tecnicas</id>
-    <link href="http://www.zotero.org/styles/associacao-brasileira-de-normas-tecnicas" rel="self"/>
-    <link href="https://forums.zotero.org/discussion/22148/how-to-apply-disambiguation-in-citation-just-when-works-of-different-authors-are-in-the-same-year/?Focus=147094#Comment_147094" rel="documentation"/>
+    <title>Associação Brasileira de Normas Técnicas - ABNT - NBR 6023.2018 (Portuguese - Brazil)</title>
+    <title-short>ABNT-NBR 6023.2018</title-short>
+    <id>https://www.zotero.org/styles/universidade-de-sao-paulo-escola-de-comunicacoes-e-artes-abnt</id>
+    <link href="http://www.zotero.org/styles/universidade-de-sao-paulo-escola-de-comunicacoes-e-artes-abnt" rel="self"/>
+    <link href="http://www.zotero.org/styles/associacao-brasileira-de-normas-tecnicas" rel="template"/>
+    <link href="https://www.abntcatalogo.com.br/norma.aspx?ID=408006" rel="documentation"/>
     <author>
-      <name>Juliana Geyna Régis</name>
-      <email>juliana.regis@ipea.gov.br</email>
+      <name>Tiago Rodrigo Marçal Murakami</name>
+      <email>trmurakami@usp.br</email>
+      <uri>https://www3.eca.usp.br/biblioteca</uri>
     </author>
-    <contributor>
-      <name>Lucas Mation</name>
-      <email>lucas.mation@ipea.gov.br</email>
-    </contributor>
-    <contributor>
-      <name>Eduardo Michelotti Bettoni</name>
-      <email>webtur@ufpr.br</email>
-    </contributor>
-    <contributor>
-      <name>Paulo Augusto Nascimento</name>
-      <email>paulo.nascimento@ipea.gov.br</email>
-    </contributor>
-    <contributor>
-      <name>Iuri Gavronski</name>
-      <email>iuri at ufrgs dot br</email>
-    </contributor>
-    <contributor>
-      <name>José Antonio Meira da Rocha</name>
-      <email>joseantoniorocha@gmail.com</email>
-      <uri>http://meiradarocha.jor.br</uri>
-    </contributor>
-    <contributor>
-      <name>Mario José</name>
-      <email>gnumario [at-mark] gmail [dot-mark] com</email>
-    </contributor>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
-    <summary>The Brazilian Standard Style in accordance with ABNT-NBR 10520.2002 and ABNT-NBR 6023.2002</summary>
-    <updated>2013-05-01T03:53:13+00:00</updated>
+    <summary>De acordo com ABNT-NBR 10520.2002 and ABNT-NBR 6023.2018</summary>
+    <updated>2019-12-16T16:31:59+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="pt-BR">
     <terms>
-      <!--Abreviacoes meses "Forma Curta"-->
       <term name="month-01" form="short">jan.</term>
       <term name="month-02" form="short">fev.</term>
       <term name="month-03" form="short">mar.</term>
@@ -57,32 +32,34 @@
       <term name="month-10" form="short">out.</term>
       <term name="month-11" form="short">nov.</term>
       <term name="month-12" form="short">dez.</term>
-      <!--Os termos abaixo serao utilizados quando houverem nomes de editores. Apos a citacao dos nomes, eles irao aparecer entre parenteses.-->
+      <term name="and">e</term>
       <term name="editor" form="short">
         <single>ed</single>
         <multiple>eds</multiple>
+      </term>
+      <term name="editor" form="short">
+        <single>org</single>
+        <multiple>org</multiple>
       </term>
       <term name="container-author" form="short">
         <single>ed</single>
         <multiple>eds</multiple>
       </term>
       <term name="collection-editor" form="short">
-        <single>ed</single>
-        <multiple>eds</multiple>
+        <single>org</single>
+        <multiple>org</multiple>
       </term>
     </terms>
   </locale>
-  <!--A macro 'container-contribuitor' e responsavel por mostrar os nomes dos editores, serao apresentados SOBRENOME, INICIAIS PRENOMES 
-tendo as inicias separadas por ponto.-->
   <macro name="container-contributors">
     <choose>
       <if type="chapter">
         <names variable="container-author" delimiter=", ">
           <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; " delimiter-precedes-last="always">
             <name-part name="family" text-case="uppercase"/>
-            <name-part name="given" text-case="uppercase"/>
+            <name-part name="given" text-case="capitalize-first"/>
           </name>
-          <label form="short" prefix=" (" suffix=".). " text-case="capitalize-first"/>
+          <label form="short" prefix=" (" suffix=".)"/>
           <substitute>
             <names variable="editor"/>
             <names variable="collection-editor"/>
@@ -91,8 +68,6 @@ tendo as inicias separadas por ponto.-->
       </if>
     </choose>
   </macro>
-  <!--A macro 'secundary-contribuitor' e responsavel por mostrar os nomes dos organizadores, serao apresentados SOBRENOME, INICIAIS PRENOMES
-tendo as inicias separadas por ponto.-->
   <macro name="secondary-contributors">
     <choose>
       <if type="chapter" match="none">
@@ -103,36 +78,19 @@ tendo as inicias separadas por ponto.-->
       </if>
     </choose>
   </macro>
-  <!--A macro 'translator' e responsavel por mostrar os nomes dos tradutores, serao apresentados SOBRENOME, INICIAIS PRENOMES
-tendo as inicias separadas por ponto. -->
-  <macro name="translator">
-    <text value="Traducao "/>
-    <names variable="translator" delimiter="; ">
-      <name delimiter="; " sort-separator=" " delimiter-precedes-last="always">
-        <name-part name="given" text-case="capitalize-first"/>
-        <name-part name="family" text-case="capitalize-first"/>
-      </name>
-    </names>
-  </macro>
-  <!--A macro 'author' e responsavel por mostrar os nomes dos autores na bibliografia, serao no formato SOBRENOME, INICIAIS PRENOMES, tendo 
-as inicias separadas por ponto. Quando houver mais de tres autores, somente o primeiro sera mostrado e no lugar dos outros
-aparecera a expess o 'et. al.'. Na regra da ABNT essa expressao deve aparecer em fonte normal-->
   <macro name="author">
     <names variable="author">
       <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; " delimiter-precedes-last="always">
         <name-part name="family" text-case="uppercase"/>
-        <name-part name="given" text-case="uppercase"/>
+        <name-part name="given" text-case="capitalize-first"/>
       </name>
       <label form="short" prefix=" (" suffix=".)" text-case="uppercase"/>
       <substitute>
         <names variable="editor"/>
-        <names variable="translator"/>
         <text macro="title"/>
       </substitute>
     </names>
   </macro>
-  <!--A macro 'author-short' e responsavel por mostrar os nomes dos autores na citacao (no meio do texto). Nela aparecera apenas o ultimo nome
-do autor. Na regra da ABNT o sobrenome deve aparecer com todas as letras em caixa alta-->
   <macro name="author-short">
     <names variable="author">
       <name form="short" name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; " delimiter-precedes-last="never">
@@ -141,80 +99,89 @@ do autor. Na regra da ABNT o sobrenome deve aparecer com todas as letras em caix
       </name>
       <substitute>
         <names variable="editor"/>
-        <names variable="translator"/>
         <choose>
           <if type="book">
             <text variable="title" form="short"/>
           </if>
           <else>
-            <text variable="title" form="short" quotes="true"/>
+            <text variable="title" form="short" text-case="uppercase" quotes="false"/>
           </else>
         </choose>
       </substitute>
     </names>
   </macro>
-  <!--A macro 'access' e utilizada em arquivos de paginas da web. Ela e responsavel por mostrar a URL do site pesquisado e a data do acesso-->
+  <macro name="director">
+    <names variable="author">
+      <name sort-separator=", " initialize-with=". " delimiter="; " delimiter-precedes-last="always">
+        <name-part name="given" text-case="capitalize-first"/>
+        <name-part name="family" text-case="capitalize-first"/>
+      </name>
+    </names>
+  </macro>
   <macro name="access">
-    <text variable="URL" prefix="Disponível em: &lt;" suffix="&gt;"/>
-    <date variable="accessed" prefix=". Acesso em: ">
+    <text variable="DOI" prefix=" DOI: " suffix="."/>
+    <text variable="URL" prefix=" Disponível em: " suffix="."/>
+    <date variable="accessed" prefix=". Acesso em: " suffix=".">
       <date-part name="day" suffix=" "/>
       <date-part name="month" form="short" suffix=". " text-case="lowercase"/>
       <date-part name="year"/>
     </date>
   </macro>
-  <!--A macro 'title' e responsavel por mostrar o titulo principal do arquivo. Em todos os tipos ele aparecera em negrito logo apos os nomes dos
-autores, exceto em arquivos do tipo 'artigo de jornal, artigo de revista, artigo de periodico', nesses arquivos eles irao aparecer em fonte normal.-->
   <macro name="title">
     <choose>
-      <if type="chapter bill" match="any">
+      <if type="chapter article-newspaper legislation article-magazine article-journal bill entry-encyclopedia paper-conference" match="any">
         <text variable="title"/>
       </if>
-      <else-if type="book thesis" match="any">
+      <else-if type="book thesis patent report" match="any">
         <text variable="title" font-weight="bold"/>
       </else-if>
-      <else-if type="article-newspaper article-magazine article-journal" match="any">
-        <text variable="title"/>
+      <else-if type="dataset" match="any">
+        <text variable="title" suffix=". "/>
+      </else-if>
+      <else-if type="broadcast motion_picture" match="any">
+        <text variable="title" text-case="uppercase"/>
       </else-if>
       <else>
         <text variable="title" font-weight="bold"/>
       </else>
     </choose>
+    <text value=""/>
   </macro>
-  <!-- Titulo dos Anais-->
   <macro name="container-title">
     <choose>
       <if type="paper-conference" match="any">
-        <text variable="container-title" suffix=". "/>
+        <text variable="container-title" text-case="uppercase"/>
+        <text variable="number" prefix=", " suffix=", "/>
+        <text macro="issued-year" prefix=" " suffix=", "/>
+        <text variable="publisher-place" suffix=". "/>
         <text value="Anais" font-weight="bold"/>
-        <text value="..."/>
+        <text value=" [...]. "/>
       </if>
       <else>
         <text variable="container-title" font-weight="bold"/>
       </else>
     </choose>
   </macro>
-  <!--A macro 'publisher' e responsavel por mostrar o nome da editora responsavel pela publicacao-->
   <macro name="publisher">
     <choose>
       <if match="any" variable="publisher-place publisher">
         <choose>
           <if variable="publisher-place">
-            <text variable="publisher-place" suffix=": "/>
+            <text variable="publisher-place"/>
           </if>
-          <else-if type="entry-encyclopedia">
-        </else-if>
+          <else-if type="entry-encyclopedia thesis" match="any"/>
+          <else-if type="paper-conference" match="any">
+            <text variable="publisher-place" suffix=". "/>
+          </else-if>
           <else>
             <text value="[s.l.] "/>
           </else>
         </choose>
         <choose>
           <if variable="publisher">
-            <text variable="publisher" suffix=", "/>
+            <text variable="publisher" prefix=": " suffix=","/>
             <text macro="issued"/>
           </if>
-          <else>
-            <text value="[s.n.]"/>
-          </else>
         </choose>
       </if>
       <else>
@@ -222,14 +189,12 @@ autores, exceto em arquivos do tipo 'artigo de jornal, artigo de revista, artigo
       </else>
     </choose>
   </macro>
-  <!--A macro 'event' sera utilizada em arquivos do tipo Evento/Conferencia. Ela e responsavel por mostrar o nome da conferencia, que tera formatacao
-em caixa alta. Utiliza-se antes do nome da conferencia a expressao "In". Segundo a regra da ABNT ela deve ser em fonte normal-->
   <macro name="event">
     <choose>
       <if variable="event">
         <choose>
           <if variable="genre" match="none">
-            <text term="in" text-case="capitalize-first" suffix=": "/>
+            <text term="in" font-style="italic" text-case="capitalize-first" suffix=": "/>
             <text variable="event" text-case="uppercase"/>
           </if>
           <else>
@@ -241,32 +206,26 @@ em caixa alta. Utiliza-se antes do nome da conferencia a expressao "In". Segundo
           </else>
         </choose>
       </if>
+      <else-if type="paper-conference" match="any"/>
     </choose>
   </macro>
-  <!--A macro 'issued' e utilizada quando devemos mostrar a data completa exemplo: 03 mar. 2011.-->
   <macro name="issued">
     <choose>
       <if variable="issued" match="any">
         <group>
-          <choose>
-            <if type="book chapter" match="none">
-              <date variable="issued">
-                <date-part name="day" suffix=" "/>
-                <date-part name="month" form="short" suffix=" "/>
-              </date>
-            </if>
-          </choose>
           <date variable="issued">
-            <date-part name="year"/>
+            <date-part name="year" prefix=" " suffix="."/>
           </date>
         </group>
       </if>
+      <else-if type="patent" match="any">
+        <date form="numeric" variable="issued" suffix="."/>
+      </else-if>
       <else>
         <text value="[s.d.]"/>
       </else>
     </choose>
   </macro>
-  <!--A macro 'issued' e utilizada quando desejamos que apareca apenas o ano-->
   <macro name="issued-year">
     <choose>
       <if variable="issued" match="any">
@@ -274,15 +233,25 @@ em caixa alta. Utiliza-se antes do nome da conferencia a expressao "In". Segundo
           <date-part name="year"/>
         </date>
       </if>
+      <else-if type="paper-conference" match="all">
+        <date date-parts="year" form="numeric" variable="issued">
+          <date-part name="year"/>
+        </date>
+      </else-if>
       <else>
         <text value="[s.d.]"/>
       </else>
     </choose>
   </macro>
-  <!--A macro 'edition' e responsavel por mostrar o numero da edicao.-->
+  <macro name="issued-legislation">
+    <date variable="issued">
+      <date-part name="day" suffix=" "/>
+      <date-part name="month" form="short" suffix=". " text-case="lowercase"/>
+      <date-part name="year"/>
+    </date>
+  </macro>
   <macro name="edition">
     <choose>
-      <!--Se for capitulo de livro aparecera somente o numero-->
       <if type="book chapter" match="any">
         <choose>
           <if is-numeric="edition">
@@ -292,17 +261,14 @@ em caixa alta. Utiliza-se antes do nome da conferencia a expressao "In". Segundo
             </group>
           </if>
           <else>
-            <!--Se for outro tipo de documento aparera o numero e depois a descricao "ed."-->
             <text variable="edition" suffix=" ed."/>
           </else>
         </choose>
       </if>
     </choose>
   </macro>
-  <!--A macro 'locators'tem como funcao mostrar os dados complementares do arquivo (paginas, secao, volume, etc)-->
   <macro name="locators">
     <choose>
-      <!--Se for projeto de lei mostrara o dia, mes "forma curta", ano, secao "Sec." e pagina "p."-->
       <if type="bill">
         <group prefix=". " delimiter=", ">
           <date variable="issued">
@@ -310,21 +276,20 @@ em caixa alta. Utiliza-se antes do nome da conferencia a expressao "In". Segundo
             <date-part prefix=" " name="month" form="short"/>
             <date-part prefix=" " name="year"/>
           </date>
-          <text variable="section" prefix="Sec. "/>
+          <text macro="section"/>
           <text variable="page" prefix="p. " suffix="."/>
         </group>
       </if>
-      <!--Se for artigos de jornal, revista, etc. Aparecera o volume "v.", edicao "n." e a pagina do artigo "p."-->
       <else-if match="any" type="article-journal article-magazine article-newspaper">
         <group delimiter=", ">
           <group delimiter=", ">
             <text variable="volume" prefix="v. "/>
             <text variable="issue" prefix="n. "/>
           </group>
+          <text variable="collection-title"/>
           <text variable="page" prefix="p. "/>
         </group>
       </else-if>
-      <!--Se for capitulo de livro aparecera o volume "v." e a pagina "p."-->
       <else-if match="any" type="book chapter">
         <group delimiter=", ">
           <group>
@@ -342,6 +307,14 @@ em caixa alta. Utiliza-se antes do nome da conferencia a expressao "In". Segundo
   <macro name="genre">
     <text variable="genre"/>
   </macro>
+  <macro name="section">
+    <choose>
+      <if match="any" variable="section issue">
+        <text variable="section"/>
+        <text variable="issue"/>
+      </if>
+    </choose>
+  </macro>
   <macro name="citation-locator">
     <group>
       <label variable="locator" form="short"/>
@@ -350,9 +323,15 @@ em caixa alta. Utiliza-se antes do nome da conferencia a expressao "In". Segundo
   </macro>
   <macro name="place">
     <choose>
-      <if match="any" variable="publisher-place">
-        <text variable="publisher-place"/>
+      <if variable="publisher-place" match="any">
+        <text variable="publisher-place" suffix=", "/>
       </if>
+      <else-if type="paper-conference" variable="publisher-place">
+        <text variable="publisher-place" suffix=". "/>
+      </else-if>
+      <else>
+        <text value="[S. l.]" font-style="italic" suffix=", "/>
+      </else>
     </choose>
   </macro>
   <macro name="archive">
@@ -360,283 +339,233 @@ em caixa alta. Utiliza-se antes do nome da conferencia a expressao "In". Segundo
       <text variable="archive" prefix=" "/>
     </group>
   </macro>
-  <!--Citacao-->
-  <!--et al. aparece a partir de 04 autores-->
   <citation et-al-min="4" et-al-use-first="1" collapse="year" disambiguate-add-year-suffix="true">
     <sort>
       <key macro="author"/>
-      <!--Puxa o autor primeiro-->
       <key variable="issued"/>
-      <!--Depois o ano-->
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
-      <!--Entre parenteses separando os autores com ponto-e-virgula-->
       <group>
         <text suffix=", " macro="author-short"/>
-        <!--Seperando os autores das datas usando virgula-->
         <text macro="issued-year"/>
         <text prefix=", " macro="citation-locator"/>
       </group>
     </layout>
   </citation>
-  <!--Bibliografia-->
-  <!--et al. aparece a partir de 04 autores-->
-  <bibliography hanging-indent="false" et-al-min="4" et-al-use-first="1" entry-spacing="1">
+  <bibliography hanging-indent="false" et-al-min="10" et-al-use-first="1" entry-spacing="1">
     <sort>
       <key macro="author"/>
-      <!--Puxa o autor primeiro-->
       <key variable="issued"/>
-      <!--Depois o ano-->
     </sort>
     <layout>
       <choose>
-        <!--Projeto de lei-->
         <if type="bill">
           <group>
             <text macro="author" suffix=". "/>
-            <!--autor-->
             <text variable="number" suffix=". "/>
-            <!--Numero da lei-->
             <text macro="title" suffix=". "/>
-            <!--Titulo-->
             <text variable="references" font-weight="bold"/>
-            <!--Historico em negrito-->
             <text variable="note"/>
-            <!--Campo 'extra' caso queira colocar alguma observacao-->
             <text macro="locators" suffix=". "/>
-            <!--Dados complementares "secao, pagina"-->
           </group>
         </if>
-        <!--Mapa-->
         <else-if type="map">
           <group>
             <text macro="author" suffix=". "/>
-            <!--autor-->
             <text macro="title" suffix=", "/>
-            <!--Titulo-->
             <text macro="issued" suffix=". "/>
-            <!--data-->
             <text variable="note" suffix=". "/>
-            <!--Campo 'extra' caso queira colocar alguma observacao-->
           </group>
         </else-if>
-        <!--Livro-->
         <else-if type="book">
           <group>
             <text macro="author" suffix=". "/>
-            <!--autor-->
             <text macro="title" suffix=". "/>
-            <!--Titulo-->
-            <text macro="translator" suffix=". "/>
-            <!--Traducao-->
             <text macro="edition" suffix=". "/>
-            <!--Edicao-->
             <text macro="publisher" suffix=". "/>
-            <!--Local, data, etc-->
             <text macro="locators"/>
-            <!--Dados complementares "pagina, volume"-->
+            <text macro="access"/>
           </group>
         </else-if>
-        <!--Conferencia-->
         <else-if type="chapter">
           <group>
             <text macro="author" suffix=". "/>
-            <!--autor-->
             <text macro="title" suffix=". "/>
-            <!--Titulo-->
-            <text macro="secondary-contributors" suffix=". "/>
-            <text term="in" text-case="capitalize-first" suffix=": "/>
-            <!--In:-->
+            <text term="in" font-style="italic" text-case="capitalize-first" suffix=": "/>
             <text macro="container-contributors" suffix=". "/>
-            <!--Nomes de editores-->
             <text macro="container-title" suffix=". "/>
-            <!--Titulo da conferencia-->
-            <text variable="collection-title" suffix=". "/>
-            <text macro="translator" suffix=". "/>
-            <!--Traducao-->
+            <text variable="collection-title"/>
             <text macro="edition" suffix=". "/>
-            <!--Edicao-->
             <text macro="publisher" suffix=". "/>
-            <!--Local, data, etc-->
             <text macro="locators" suffix=". "/>
-            <!--Dados complementares "pagina, volume"-->
+            <text macro="access"/>
           </group>
         </else-if>
-        <!--Artigo de revista, jornal, etc-->
         <else-if type="article-newspaper article-magazine article-journal" match="any">
           <group>
             <text macro="author" suffix=". "/>
-            <!--Autor-->
             <text macro="title" suffix=". "/>
-            <!--Titulo do artigo-->
             <text macro="container-title" suffix=", "/>
-            <!--Titulo da publicacao-->
-            <text variable="collection-title" suffix=". "/>
-            <!--Titulo da serie-->
+            <text macro="collection-title" suffix=". "/>
+            <text macro="place"/>
             <text macro="edition" suffix=", "/>
-            <!--Edicao-->
             <text macro="locators" suffix=", "/>
-            <!--Dados complementares "pagina, volume"-->
             <text macro="issued" suffix=". "/>
-            <!--Data-->
+            <text macro="access"/>
           </group>
         </else-if>
-        <!--Tese-->
         <else-if type="thesis">
           <group>
             <text macro="author" suffix=". "/>
-            <!--Autor-->
             <text macro="title" suffix=". "/>
-            <!--Titulo-->
-            <text macro="genre" suffix="&#8212;"/>
-            <!--Tipo-->
-            <text macro="publisher" suffix="."/>
-            <!--Local, data, etc-->
+            <text macro="issued-year" suffix=". "/>
+            <text macro="genre" suffix=" - "/>
+            <text variable="publisher" suffix=", "/>
+            <text macro="place"/>
+            <text macro="issued" suffix="."/>
+            <text macro="access"/>
           </group>
         </else-if>
-        <!-- Nao ha norma ABNT para manuscritos -->
         <else-if type="manuscript">
           <group>
             <text macro="author" suffix=". "/>
-            <!--Autor-->
             <text macro="title" suffix=". "/>
-            <!--Titulo-->
             <text macro="edition" suffix=". "/>
-            <!--Edicao-->
             <text macro="place" suffix=", "/>
             <text macro="issued" suffix=". "/>
-            <!--Data-->
             <text macro="access" suffix=". "/>
-            <!--URL, data do acesso-->
             <text macro="archive" suffix=". "/>
-            <!--Arquive-->
           </group>
         </else-if>
-        <!--Pagina da WEB-->
         <else-if type="webpage">
           <group>
             <text macro="author" suffix=". "/>
-            <!--Autor-->
             <text macro="title" suffix=". "/>
-            <!--Titulo-->
             <text macro="genre" suffix=". "/>
+            <text macro="issued-year" suffix="."/>
             <text macro="access" suffix=". "/>
-            <!--URL, data do acesso-->
           </group>
         </else-if>
-        <!--Relatorio-->
         <else-if type="report">
           <group>
             <text macro="author" suffix=". "/>
-            <!--Autor-->
             <text macro="title"/>
-            <!--Titulo-->
             <text macro="container-contributors"/>
-            <!--Nomes de editores-->
             <text macro="secondary-contributors"/>
             <text macro="container-title"/>
-            <!--Titulo da publicacao-->
             <text variable="collection-title" prefix=": "/>
             <text macro="locators"/>
-            <!--Dados complementares "pagina, volume"-->
             <text macro="event"/>
-            <!--Nome do evento, conferencia-->
             <text macro="publisher" prefix=". " suffix=". "/>
-            <!--Local, data, etc-->
             <text macro="access" suffix="."/>
-            <!--URL, data do acesso-->
           </group>
         </else-if>
-        <!--Texto para Discussao (Verbete de Dicionario)-->
         <else-if type="entry-dictionary">
           <group>
             <text macro="author" suffix=". "/>
-            <!--Autor-->
             <text macro="title"/>
-            <!--Titulo-->
             <text macro="container-contributors"/>
-            <!--Nomes de editores-->
             <text macro="secondary-contributors"/>
             <text macro="container-title"/>
-            <!--Titulo da publicacao-->
             <text variable="collection-title" prefix=": " suffix=". "/>
             <text macro="locators"/>
-            <!--Dados complementares "pagina, volume"-->
             <text macro="event"/>
-            <!--Nome do evento, conferencia-->
             <text macro="publisher" prefix=". " suffix=". "/>
-            <!--Local, data, etc-->
             <text macro="collection-title" prefix="(Texto para discussao, n. " suffix=")."/>
             <text macro="access"/>
-            <!--URL, data do acesso-->
           </group>
         </else-if>
-        <!--Nota Tecnica (Verbete de Enciclopedia)-->
         <else-if type="entry-encyclopedia">
           <group>
             <text macro="author" suffix=". "/>
-            <!--Autor-->
-            <text macro="title"/>
-            <!--Titulo-->
+            <text macro="title" suffix=". "/>
+            <text term="in" font-style="italic" text-case="capitalize-first" suffix=": "/>
+            <text macro="container-title" suffix="."/>
             <text variable="publisher-place" prefix=". " suffix=": "/>
-            <!--Local-->
-            <text variable="publisher" suffix=", "/>
-            <!--Editor-->
-            <text macro="issued" prefix=", " suffix=". (Nota técnica)."/>
-            <!--Data-->
+            <text variable="publisher"/>
+            <text macro="issued" prefix="," suffix=". "/>
           </group>
         </else-if>
         <else-if type="paper-conference">
           <text macro="author" suffix=". "/>
-          <!--Autor-->
-          <text macro="title" suffix=". "/>
-          <!--Titulo-->
-          <text macro="container-contributors"/>
-          <!--Nomes de editore-->
+          <text macro="title" suffix="."/>
+          <text term="in" font-style="italic" text-case="capitalize-first" prefix=" " suffix=": "/>
+          <text macro="container-contributors" text-case="uppercase"/>
           <text macro="secondary-contributors"/>
           <text macro="container-title"/>
-          <!--Titulo da publicacao-->
-          <text variable="collection-title" prefix=": " suffix="."/>
           <text macro="locators"/>
-          <!--Dados complementares "pagina, volume"-->
           <group delimiter=". " prefix=". " suffix=". ">
             <text macro="event"/>
-            <!--Nome do evento, conferencia-->
           </group>
-          <text variable="publisher-place" suffix=": "/>
-          <!--Local-->
-          <text variable="publisher" suffix=", "/>
-          <!--Editor-->
-          <text macro="issued"/>
-          <!--Data-->
+          <text macro="publisher"/>
+          <text variable="page" prefix=" p. " suffix="."/>
           <text macro="access"/>
-          <!--URL, data do acesso-->
+        </else-if>
+        <else-if type="legislation legal_case" match="any">
+          <group>
+            <text macro="author" suffix=". "/>
+            <text macro="title"/>
+            <text variable="abstract" prefix=". " suffix=". "/>
+            <text macro="container-title" suffix=", "/>
+            <text variable="publisher-place" suffix=", "/>
+            <text macro="issued-legislation" suffix=". "/>
+            <text macro="section" prefix="Seção " suffix=", "/>
+            <text variable="page" prefix="p. " suffix="."/>
+            <text macro="access"/>
+          </group>
+        </else-if>
+        <else-if type="patent" match="any">
+          <group>
+            <text macro="author" suffix=". "/>
+            <text macro="title" prefix=" "/>
+            <text variable="number" prefix=", " suffix=", "/>
+            <text macro="issued" suffix=". "/>
+          </group>
+        </else-if>
+        <else-if type="interview song speech" match="any">
+          <group>
+            <text macro="author" suffix=". "/>
+            <text macro="title" suffix=". "/>
+            <text macro="publisher"/>
+            <text variable="medium"/>
+          </group>
+        </else-if>
+        <else-if type="broadcast motion_picture" match="any">
+          <group>
+            <text macro="title"/>
+            <text value="Direção" text-case="capitalize-first" prefix=". " suffix=": "/>
+            <text macro="director" suffix=". "/>
+            <text macro="publisher"/>
+            <text variable="medium"/>
+            <text macro="access"/>
+          </group>
+        </else-if>
+        <else-if type="dataset" match="any">
+          <group>
+            <text macro="author"/>
+            <text macro="title" suffix=". "/>
+            <text variable="version" prefix=". "/>
+            <text macro="publisher"/>
+            <text variable="medium"/>
+            <text macro="access"/>
+          </group>
         </else-if>
         <else>
           <text macro="author" suffix=". "/>
-          <!--Autor-->
           <text macro="title"/>
-          <!--Titulo-->
           <text macro="container-contributors"/>
-          <!--Nomes de editore-->
           <text macro="secondary-contributors"/>
           <text macro="container-title"/>
-          <!--Titulo da publicacao-->
           <text variable="collection-title" prefix=": " suffix="."/>
           <text macro="locators"/>
-          <!--Dados complementares "pagina, volume"-->
           <group delimiter=". " prefix=". " suffix=". ">
             <text macro="event"/>
-            <!--Nome do evento, conferencia-->
           </group>
           <text variable="publisher-place"/>
-          <!--Local-->
           <text variable="publisher" suffix=", "/>
-          <!--Editor-->
           <text macro="issued" prefix=", " suffix=". "/>
-          <!--Data-->
           <text macro="access"/>
-          <!--URL, data do acesso-->
+          <text variable="medium"/>
         </else>
       </choose>
     </layout>


### PR DESCRIPTION
Updating to the latest ABNT standard

According to a librarian specialized in this standard, https://www.zotero.org/styles/universidade-de-sao-paulo-escola-de-comunicacoes-e-artes-abnt is a more correct and current implementation. Change only in the title to make it clear that it is the updated standard and not the name of the institution that updated this template.