### PR TITLE
Adds full stop after title writing in ABNT style

### DIFF
--- a/citation-styles/associacao-brasileira-de-normas-tecnicas.csl
+++ b/citation-styles/associacao-brasileira-de-normas-tecnicas.csl
@@ -552,7 +552,7 @@
         </else-if>
         <else>
           <text macro="author" suffix=". "/>
-          <text macro="title"/>
+          <text macro="title" suffix=". "/>
           <text macro="container-contributors"/>
           <text macro="secondary-contributors"/>
           <text macro="container-title"/>


### PR DESCRIPTION
After using this plugin in production, we noticed a problem with the ABNT citation format. It wrote the submission title and context name together, without a delimiter:

`CABRAL, J. F.; Factors associated with functional disability in older adultsSciELO Preprints`

After our change, it is formatted like this:

`CABRAL, J. F.; Factors associated with functional disability in older adults. SciELO Preprints`

The same changing was accepted by CSL in a previous [pull request](https://github.com/citation-style-language/styles/pull/6031).